### PR TITLE
Fix bug causing valid messages to be removed when closed/deleted questions removed

### DIFF
--- a/UnclosedRequestReview.user.js
+++ b/UnclosedRequestReview.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Unclosed Request Review Script
 // @namespace    http://github.com/Tiny-Giant
-// @version      1.0.1.4
+// @version      1.0.2.0
 // @description  Adds a button to the chat buttons controls; clicking on the button takes you to the recent unclosed close vote request query, then it scans the results  for closed or deleted requests, or false positives and hides them.
 // @author       @TinyGiant @rene @mogsdad @Makyen
 // @match        *://chat.stackoverflow.com/rooms/41570/*
@@ -364,5 +364,16 @@
                                       {
             window.open(window.location.origin + '/search?q=tagged%2Fcv-pls&Room=41570&page=1&pagesize=50&sort=newest');
         }, false);
+
+        //Apply the same visited link style on the main chat page as we have on the requests search page.
+        let scope = document.body;
+        let style = document.createElement('style');
+        style.type = 'text/css';
+        style.textContent = [
+            '.content a:visited {',
+            '    color: #0480DE;',
+            '}'
+        ].join('\n');
+        scope.appendChild(style);
     }
 })();


### PR DESCRIPTION
A prior fix disabled the functionality of not showing closed/deleted questions. This was done because some messages were being deleted from the DOM which were valid.
Fix the root cause of those messages being misidentified as closed/deleted (with some HTML, multiple requests were added for a single question in a message).
Restore the functionality of not showing closed/deleted questions.
In addition, add a check to prevent removing any messages to which a request-info has been added.