### PR TITLE
Add MIT License and brief Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+By contributing to this repository (e.g. by submitting a commit, a PR, an issue, etc.) you agree to license your contribution under the MIT License.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,24 @@
+## MIT License (contributions after 2020-01-01 & some earlier contributions)
+
+Copyright 2014-current by the individual contributors to the https://github.com/SO-Close-Vote-Reviewers/UserScripts repository
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## Earlier Contributions
+As of the creation of this file on 2020-01-01, all future contributions to this repository are licensed under the MIT License.
+
+Unfortunately, there was no actual license for contributions prior to 2020-01-01. As such, in order for the code that existed prior to that to have a license, each earlier contributor must individually agree to license their existing contributions under the MIT License.
+
+As a result, the license for the code in this repository is complex. If you intend to use the code in this repository, you will need to verify for yourself that the portions of code you desire to use are covered under the MIT License. You can check if the contribution containing original version of the code you desire to use was made on or after the creation of this file (2020-01-01), or if the author of the contribution has added their name below.
+
+Prior contributors can indicate their agreement to license their existing contributions under the MIT License by editing this file with the GitHub account from which the prior contribution(s) were made and adding their GitHub username below.
+
+Individuals who have no contributions prior to 2020-01-01 do not need to add their name to the list below, as they agreed to grant a license under the above MIT License at the time they made the contribution.
+
+I license all of my contributions to this repository under the MIT License:
+
+* Makyen

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-## MIT License (contributions after 2020-01-01 & some earlier contributions)
+## MIT License (contributions after 2020-04-15T00:00:00.000Z and some earlier contributions)
 
-Copyright 2014-current by the individual contributors to the https://github.com/SO-Close-Vote-Reviewers/UserScripts repository
+Copyright 2014 – current by the individual contributors to the https://github.com/SO-Close-Vote-Reviewers/UserScripts repository.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -9,15 +9,19 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ## Earlier Contributions
-As of the creation of this file on 2020-01-01, all future contributions to this repository are licensed under the MIT License.
+As of 2020-04-15T00:00:00.000Z, all future contributions to this repository are licensed under the MIT License.
 
-Unfortunately, there was no actual license for contributions prior to 2020-01-01. As such, in order for the code that existed prior to that to have a license, each earlier contributor must individually agree to license their existing contributions under the MIT License.
+Unfortunately, there was no actual license for contributions prior to that date. As such, in order for the code that existed prior to that to have a license, each earlier contributor must individually agree to license their existing contributions under the MIT License.
 
-As a result, the license for the code in this repository is complex. If you intend to use the code in this repository, you will need to verify for yourself that the portions of code you desire to use are covered under the MIT License. You can check if the contribution containing original version of the code you desire to use was made on or after the creation of this file (2020-01-01), or if the author of the contribution has added their name below.
+As a result, the license for the code in this repository is complex. If you intend to use the code in this repository, you will need to verify for yourself that the portions of code you desire to use are covered under the MIT License. To know if the code has a license, or not, you will need to check if the contribution containing the original version of the code you desire to use was made on or after 2020-04-15T00:00:00.000Z or if the author of the contribution has added their name below.
 
-Prior contributors can indicate their agreement to license their existing contributions under the MIT License by editing this file with the GitHub account from which the prior contribution(s) were made and adding their GitHub username below.
+### Agreement by authors to license contributions made prior to 2020-04-15T00:00:00.000Z
 
-Individuals who have no contributions prior to 2020-01-01 do not need to add their name to the list below, as they agreed to grant a license under the above MIT License at the time they made the contribution.
+Authors who made contributions prior to 2020-04-15T00:00:00.000Z can indicate their agreement to license their earlier contributions under the MIT License by editing this file with the GitHub account from which the prior contribution(s) were made and adding their GitHub username below.
+
+Individuals who have no contributions prior to 2020-04-15T00:00:00.000Z may optionally add their name to the list below, but just making a contribution after that date indicates agreement to license such new contribution under the above MIT license.
+
+#### List of authors licensing their prior (and future) contributions
 
 I license all of my contributions to this repository under the MIT License:
 


### PR DESCRIPTION
Add the MIT License for future contributions.

For existing contributions, we have to get authorization for using the MIT License from each author. I've written that up and provided a way for authors to indicate their agreement with licensing their earlier contributions under the MIT License.