### PR TITLE
Add "Ministry of Silly Hats" to CVRequestArchiver

### DIFF
--- a/CVRequestArchiver.user.js
+++ b/CVRequestArchiver.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         CV Request Archiver
 // @namespace    https://github.com/SO-Close-Vote-Reviewers/
-// @version      3.3.0
+// @version      3.3.1
 // @description  Scans the chat transcript and checks all cv+delete+undelete+reopen+dupe requests and SD, FireAlarm, Queen, etc. reports for status, then moves the completed or expired ones.
 // @author       @TinyGiant @rene @Tunaki @Makyen
 // @updateURL    https://github.com/SO-Close-Vote-Reviewers/UserScripts/raw/master/CVRequestArchiver.user.js
@@ -229,6 +229,18 @@
                     new TargetRoom(23262, soChat, 'Trash can', 'Trash', trashcanEmoji, 'Trash', commonRoomOptions.noUI),
                 ]),
             },
+            {//Ministry of Silly Hats
+                name: 'Ministry of Silly Hats',
+                primeRoom: 92764,
+                chatServer: soChat,
+                defaultTargetRoom: 23262,
+                rooms: makeRoomsByNumberObject([
+                    //Ministry of Silly Hats (for extended, off-topic discussions)
+                    new TargetRoom(92764, soChat, 'Ministry of Silly Hats', 'Ministry', 'M', 'Ministry', commonRoomOptions.allTrue),
+                    //Trash can
+                    new TargetRoom(23262, soChat, 'Trash can', 'Trash', trashcanEmoji, 'Trash', commonRoomOptions.noUI),
+                ]),
+            },
             {//SOCVR
                 name: 'SOCVR',
                 primeRoom: 41570,
@@ -245,6 +257,8 @@
                     new TargetRoom(68414, soChat, 'SOCVR Testing Facility', 'Testing', 'Te', 'Test', commonRoomOptions.allTrue),
                     //Private for SD posts that have especially offensive content.
                     new TargetRoom(170175, soChat, 'Private Trash', 'Private', 'P', 'Private', commonRoomOptions.noUI),
+                    //Ministry of Silly Hats (for extended, off-topic discussions)
+                    new TargetRoom(92764, soChat, 'Ministry of Silly Hats', 'Ministry', 'M', 'Ministry', commonRoomOptions.targetOnly),
                 ]),
                 //Semi-auto scanning:
                 //On Chat.SO, many of the properties are common for all rooms. Those are in soChatScanning. However,


### PR DESCRIPTION
The "Ministry of Silly Hats" is added as a destination room for SOCVR, since it is often used as a place to shunt over extended and/or off-topic discussions.

(This PR arose out of my frustration a few moments ago at having carefully selected the individual messages to be migrated using the script's tooling, and then finding that the Ministry was not one of the supported destinations. I then had to re-select the exact same messages using the chat server's built-in move messages tool. That does work just as well, unless you do the wrong thing first, then it works substantially less well. Having the Ministry as a standard destination frees one from having to remember two different workflows and choosing the correct one at the outset.)

However, it's more like a black hole in the sense that no messages should ever be migrated from it *into* SOCVR, so a separate category was created for this room, making it otherwise behave like the SO chat defaults.