### PR TITLE
Fix exception: observe argument not object

### DIFF
--- a/SECloseVoteRequestGenerator.user.js
+++ b/SECloseVoteRequestGenerator.user.js
@@ -5091,6 +5091,7 @@
         const topbarStyleObserver = new MutationObserver(adjustTopbarMarginToNotifyContainer);
 
         function startObservingTopbarStyle() {
+            if (!topBar.length) return
             topbarStyleObserver.observe(topBar[0], {
                 attributes: true,
                 attributeFilter: [


### PR DESCRIPTION
This user script always creates an exception on page load without this check